### PR TITLE
[add] role_session_name オプションを追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 config.ini
 extension.ini
-
+CLAUDE.md
+issue/

--- a/README.md
+++ b/README.md
@@ -48,6 +48,9 @@ aws-prof --format=extension
 # ~/.aws/config 用の設定を標準出力
 aws-prof --format=config
 
+# role_session_nameを指定
+aws-prof --role-session-name=claude --format=config
+
 # 指定したファイルに設定を出力
 aws-prof --format=extension --output=profiles.txt
 
@@ -115,6 +118,7 @@ role_arn = arn:aws:iam::123456789012:role/ReadOnlySwitchRole
 |-----------|------|
 | `--format` | 出力形式 (extension/config) |
 | `--output` | 出力ファイルパス |
+| `--role-session-name` | ~/.aws/configのrole_session_name設定 (デフォルト: user_name) |
 
 ## AWS Extend Switch Role の色を設定
 

--- a/claude-wrapper.sh
+++ b/claude-wrapper.sh
@@ -1,0 +1,89 @@
+#!/bin/bash
+
+# Slack Webhook URL
+SLACK_WEBHOOK_URL="https://hooks.slack.com/services/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"
+SLACK_CHANNEL="#claude-code"
+
+# プロジェクト情報
+PROJECT_NAME="ai-aws-profiles"
+PROJECT_DIR=$(pwd)
+
+# Slack通知関数
+send_slack_notification() {
+    local message="$1"
+    local color="$2"
+    local timestamp=$(date '+%Y-%m-%d %H:%M:%S')
+    
+    local payload=$(cat <<EOF
+{
+    "channel": "$SLACK_CHANNEL",
+    "username": "Claude Code",
+    "icon_emoji": ":robot_face:",
+    "attachments": [
+        {
+            "color": "$color",
+            "fields": [
+                {
+                    "title": "Project",
+                    "value": "$PROJECT_NAME",
+                    "short": true
+                },
+                {
+                    "title": "Directory",
+                    "value": "$PROJECT_DIR",
+                    "short": true
+                },
+                {
+                    "title": "Time",
+                    "value": "$timestamp",
+                    "short": true
+                },
+                {
+                    "title": "Status",
+                    "value": "$message",
+                    "short": false
+                }
+            ]
+        }
+    ]
+}
+EOF
+    )
+    
+    curl -X POST -H 'Content-type: application/json' \
+         --data "$payload" \
+         "$SLACK_WEBHOOK_URL" \
+         --silent > /dev/null
+}
+
+# ログファイル
+LOG_FILE="/tmp/claude-code-session-$$.log"
+
+# 実行開始通知
+echo "Starting Claude Code session..."
+
+# Claude Codeを実行し、出力を監視
+claude "$@" 2>&1 | tee "$LOG_FILE" | while IFS= read -r line; do
+    echo "$line"
+    
+    # ユーザー許可が必要なパターンを検出
+    if echo "$line" | grep -qE "(Do you want to|Would you like to|Proceed|Continue|Allow|Confirm|Permission required|Authorization needed|\[Y/n\]|\[y/N\])"; then
+        send_slack_notification "🔐 Permission required: $line" "warning"
+    elif echo "$line" | grep -qE "(Error|Failed|Exception|denied|refused)"; then
+        send_slack_notification "❌ Error occurred: $line" "danger"
+    fi
+done
+
+# 実行完了の判定
+EXIT_CODE=${PIPESTATUS[0]}
+
+if [ $EXIT_CODE -eq 0 ]; then
+    send_slack_notification "✅ Claude Code session completed successfully" "good"
+else
+    send_slack_notification "❌ Claude Code session failed (exit code: $EXIT_CODE)" "danger"
+fi
+
+# ログファイルを削除
+rm -f "$LOG_FILE"
+
+exit $EXIT_CODE

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -11,9 +11,10 @@ import (
 )
 
 var (
-	format   string
-	output   string
-	version  = "1.0.0"
+	format         string
+	output         string
+	roleSessionName string
+	version        = "1.0.0"
 )
 
 var rootCmd = &cobra.Command{
@@ -38,6 +39,7 @@ var versionCmd = &cobra.Command{
 func init() {
 	rootCmd.Flags().StringVar(&format, "format", "", "Output format (extension/config)")
 	rootCmd.Flags().StringVar(&output, "output", "", "Output file path")
+	rootCmd.Flags().StringVar(&roleSessionName, "role-session-name", "user_name", "Role session name for AWS config")
 	rootCmd.AddCommand(versionCmd)
 }
 
@@ -47,6 +49,8 @@ func runAWSProf(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return fmt.Errorf("failed to fetch accounts from AWS: %w", err)
 	}
+
+	generator.SetRoleSessionName(roleSessionName)
 
 	if format == "" {
 		return writeDefaultOutput(generator)

--- a/internal/profile.go
+++ b/internal/profile.go
@@ -12,15 +12,21 @@ type Profile struct {
 }
 
 type Generator struct {
-	Profiles     []Profile
-	ColorManager *ColorManager
+	Profiles        []Profile
+	ColorManager    *ColorManager
+	RoleSessionName string
 }
 
 func NewGenerator() *Generator {
 	cm := NewColorManager()
 	return &Generator{
-		ColorManager: cm,
+		ColorManager:    cm,
+		RoleSessionName: "user_name",
 	}
+}
+
+func (g *Generator) SetRoleSessionName(name string) {
+	g.RoleSessionName = name
 }
 
 func (g *Generator) AddProfile(name, roleArn string) {
@@ -64,7 +70,7 @@ func (g *Generator) GenerateConfigFormat() string {
 	output.WriteString("[default]\n")
 	output.WriteString("region = ap-northeast-1\n")
 	output.WriteString("output = json\n")
-	output.WriteString("role_session_name = user_name\n\n")
+	output.WriteString(fmt.Sprintf("role_session_name = %s\n\n", g.RoleSessionName))
 	
 	for _, profile := range g.Profiles {
 		output.WriteString(fmt.Sprintf("[profile %s]\n", profile.Name))

--- a/internal/profile_test.go
+++ b/internal/profile_test.go
@@ -124,3 +124,37 @@ func TestGenerateConfigFormat(t *testing.T) {
 	}
 }
 
+func TestSetRoleSessionName(t *testing.T) {
+	generator := NewGenerator()
+	
+	if generator.RoleSessionName != "user_name" {
+		t.Errorf("Expected default RoleSessionName 'user_name', got '%s'", generator.RoleSessionName)
+	}
+	
+	generator.SetRoleSessionName("claude")
+	
+	if generator.RoleSessionName != "claude" {
+		t.Errorf("Expected RoleSessionName 'claude', got '%s'", generator.RoleSessionName)
+	}
+}
+
+func TestGenerateConfigFormatWithCustomRoleSessionName(t *testing.T) {
+	generator := NewGenerator()
+	generator.ColorManager.Rules = []ColorRule{
+		{Pattern: "admin", Color: "6644FF"},
+	}
+	
+	generator.SetRoleSessionName("claude")
+	generator.AddProfile("test-admin", "arn:aws:iam::123456789012:role/AdminSwitchRole")
+	
+	output := generator.GenerateConfigFormat()
+	
+	if !strings.Contains(output, "role_session_name = claude") {
+		t.Errorf("Expected output to contain 'role_session_name = claude', but it didn't. Output:\n%s", output)
+	}
+	
+	if strings.Contains(output, "role_session_name = user_name") {
+		t.Errorf("Expected output NOT to contain 'role_session_name = user_name', but it did. Output:\n%s", output)
+	}
+}
+


### PR DESCRIPTION
## 概要
`~/.aws/config` の「role_session_name = user_name」を任意のユーザー名に設定できるように、コマンドのオプションとして追加しました。

## 背景
現在はrole_session_nameが固定のuser_nameになっているが、より柔軟に設定できるようにしたい要望がありました（Issue #1）。

## 内容詳細
- `--role-session-name` オプションを追加
- デフォルトはuser_nameのまま維持
- `SetRoleSessionName`メソッドをGeneratorに追加
- テストケースを追加
- READMEに使用方法を記載

### 使用例
```bash
aws-prof --role-session-name=claude --format=config
```

### 追加実装
Claude Code実行時のSlack通知機能も併せて実装：
- `claude-wrapper.sh`を作成
- 実行完了時、エラー時、ユーザー許可必要時に`#claude-code`チャンネルに通知

## レビューポイント
- CLIオプションの追加
- 既存の動作を維持しつつ新機能を追加
- テストケースの網羅性
- Slack通知機能の動作確認

Closes #1

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a new command-line option to specify the AWS role session name when generating configuration profiles.
  - Introduced a wrapper script that runs the `claude` tool and sends real-time notifications to Slack based on output events and execution status.

- **Documentation**
  - Updated documentation to include the new command-line option and example usage.

- **Tests**
  - Added tests to verify customization of the role session name in generated AWS configuration output.

- **Chores**
  - Updated ignore rules to exclude specific files and directories from version control.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->