### PR TITLE
[add] role_session_name オプションの追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,9 @@ aws-prof --format=extension
 # ~/.aws/config 用の設定を標準出力
 aws-prof --format=config
 
+# role_session_nameを指定
+aws-prof --role-session-name=claude --format=config
+
 # 指定したファイルに設定を出力
 aws-prof --format=extension --output=profiles.txt
 
@@ -115,6 +118,7 @@ role_arn = arn:aws:iam::123456789012:role/ReadOnlySwitchRole
 |-----------|------|
 | `--format` | 出力形式 (extension/config) |
 | `--output` | 出力ファイルパス |
+| `--role-session-name` | ~/.aws/configのrole_session_name設定 (デフォルト: user_name) |
 
 ## AWS Extend Switch Role の色を設定
 

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -11,9 +11,10 @@ import (
 )
 
 var (
-	format   string
-	output   string
-	version  = "1.0.0"
+	format         string
+	output         string
+	roleSessionName string
+	version        = "1.0.0"
 )
 
 var rootCmd = &cobra.Command{
@@ -38,6 +39,7 @@ var versionCmd = &cobra.Command{
 func init() {
 	rootCmd.Flags().StringVar(&format, "format", "", "Output format (extension/config)")
 	rootCmd.Flags().StringVar(&output, "output", "", "Output file path")
+	rootCmd.Flags().StringVar(&roleSessionName, "role-session-name", "user_name", "Role session name for AWS config")
 	rootCmd.AddCommand(versionCmd)
 }
 
@@ -47,6 +49,8 @@ func runAWSProf(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return fmt.Errorf("failed to fetch accounts from AWS: %w", err)
 	}
+
+	generator.SetRoleSessionName(roleSessionName)
 
 	if format == "" {
 		return writeDefaultOutput(generator)

--- a/internal/profile.go
+++ b/internal/profile.go
@@ -12,15 +12,21 @@ type Profile struct {
 }
 
 type Generator struct {
-	Profiles     []Profile
-	ColorManager *ColorManager
+	Profiles        []Profile
+	ColorManager    *ColorManager
+	RoleSessionName string
 }
 
 func NewGenerator() *Generator {
 	cm := NewColorManager()
 	return &Generator{
-		ColorManager: cm,
+		ColorManager:    cm,
+		RoleSessionName: "user_name",
 	}
+}
+
+func (g *Generator) SetRoleSessionName(name string) {
+	g.RoleSessionName = name
 }
 
 func (g *Generator) AddProfile(name, roleArn string) {
@@ -64,7 +70,7 @@ func (g *Generator) GenerateConfigFormat() string {
 	output.WriteString("[default]\n")
 	output.WriteString("region = ap-northeast-1\n")
 	output.WriteString("output = json\n")
-	output.WriteString("role_session_name = user_name\n\n")
+	output.WriteString(fmt.Sprintf("role_session_name = %s\n\n", g.RoleSessionName))
 	
 	for _, profile := range g.Profiles {
 		output.WriteString(fmt.Sprintf("[profile %s]\n", profile.Name))

--- a/internal/profile_test.go
+++ b/internal/profile_test.go
@@ -124,3 +124,37 @@ func TestGenerateConfigFormat(t *testing.T) {
 	}
 }
 
+func TestSetRoleSessionName(t *testing.T) {
+	generator := NewGenerator()
+	
+	if generator.RoleSessionName != "user_name" {
+		t.Errorf("Expected default RoleSessionName 'user_name', got '%s'", generator.RoleSessionName)
+	}
+	
+	generator.SetRoleSessionName("claude")
+	
+	if generator.RoleSessionName != "claude" {
+		t.Errorf("Expected RoleSessionName 'claude', got '%s'", generator.RoleSessionName)
+	}
+}
+
+func TestGenerateConfigFormatWithCustomRoleSessionName(t *testing.T) {
+	generator := NewGenerator()
+	generator.ColorManager.Rules = []ColorRule{
+		{Pattern: "admin", Color: "6644FF"},
+	}
+	
+	generator.SetRoleSessionName("claude")
+	generator.AddProfile("test-admin", "arn:aws:iam::123456789012:role/AdminSwitchRole")
+	
+	output := generator.GenerateConfigFormat()
+	
+	if !strings.Contains(output, "role_session_name = claude") {
+		t.Errorf("Expected output to contain 'role_session_name = claude', but it didn't. Output:\n%s", output)
+	}
+	
+	if strings.Contains(output, "role_session_name = user_name") {
+		t.Errorf("Expected output NOT to contain 'role_session_name = user_name', but it did. Output:\n%s", output)
+	}
+}
+


### PR DESCRIPTION
## 概要
`~/.aws/config` の「role_session_name = user_name」を任意のユーザー名に設定できるように、コマンドのオプションとして追加しました。

## 背景
現在はrole_session_nameが固定のuser_nameになっているが、より柔軟に設定できるようにしたい要望がありました（Issue #1）。

## 内容詳細
- `--role-session-name` オプションを追加
- デフォルトはuser_nameのまま維持（後方互換性を保持）
- `SetRoleSessionName`メソッドをGeneratorに追加
- 包括的なテストケースを追加
- READMEに使用方法と新オプションの説明を記載

### 使用例
```bash
# デフォルト（従来通り）
aws-prof --format=config

# カスタムrole_session_name
aws-prof --role-session-name=claude --format=config
```

### 出力例
```ini
[default]
region = ap-northeast-1
output = json
role_session_name = claude

[profile test-admin]
source_profile = default
role_arn = arn:aws:iam::123456789012:role/AdminSwitchRole
```

## レビューポイント
- CLIオプションの追加実装
- 既存の動作を維持しつつ新機能を追加
- テストケースの網羅性
- 後方互換性の確保

Closes #1

🤖 Generated with [Claude Code](https://claude.ai/code)